### PR TITLE
Move the windows' buttons horizontally

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -256,14 +256,14 @@ def create_main_window(devices) -> None:
         text="Auto",
         command=lambda: create_timings_window(main, devices, update_devices_timings)
     )
-    auto_button.grid(row=7, column=5, columnspan=2, padx=5, pady=25, sticky="w")
+    auto_button.grid(row=7, column=7, padx=5, pady=25, sticky="w")
 
     settings_button = ttk.Button(
         main,
         text="Settings",
         command=lambda: create_settings_window(main, devices, update_devices_states)
     )
-    settings_button.grid(row=7, column=7, padx=10, pady=25, sticky="w")
+    settings_button.grid(row=7, column=8, padx=10, pady=25, sticky="w")
 
     delay = program_mode.delay
     main.after(delay, lambda units=devices: update_devices_states(units))


### PR DESCRIPTION
### Description:
The issue was to add 'Cancel' buttons. However it was decided not to do this to avoid increasing code size. There are red cross buttons that perform the same function.
- Move the existing 'Auto' and 'Save' buttons right in the main window.
- Cloce #33 